### PR TITLE
Split FileCollector tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,10 @@ if(BUILD_TESTS)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 
-    add_executable(test_custom_grep tests/TestCustomGrep.cpp)
+    add_executable(test_custom_grep
+        tests/TestCustomGrep.cpp
+        tests/TestFileCollector.cpp
+    )
     target_link_libraries(test_custom_grep PRIVATE CustomGrep GTest::gtest_main)
     target_include_directories(test_custom_grep PRIVATE ${CMAKE_SOURCE_DIR}/inc)
 

--- a/tests/TestCustomGrep.cpp
+++ b/tests/TestCustomGrep.cpp
@@ -45,38 +45,6 @@ static void removeDirIfExists(const fs::path& dir)
     }
 }
 
-TEST(CollectFiles, NestedDirectories)
-{
-    auto base = fs::temp_directory_path() / "custom_grep_test_dir";
-    removeDirIfExists(base);
-    fs::create_directories(base / "subdir1");
-    fs::create_directories(base / "subdir2" / "nested");
-
-    writeFile(base / "root1.txt", { "hello" });
-    writeFile(base / "root2.log", { "foo", "bar" });
-    writeFile(base / "subdir1" / "inside1.txt", { "inside" });
-    writeFile(base / "subdir1" / "inside2.txt", { "another" });
-    writeFile(base / "subdir2" / "nested" / "deep.txt", { "deep" });
-
-    auto files = cgrep::FileCollector::collectFiles(base);
-    EXPECT_EQ(files.size(), 5u);
-
-    std::set<fs::path> found(files.begin(), files.end());
-    std::vector<fs::path> expected =
-    {
-        base / "root1.txt",
-        base / "root2.log",
-        base / "subdir1" / "inside1.txt",
-        base / "subdir1" / "inside2.txt",
-        base / "subdir2" / "nested" / "deep.txt"
-    };
-    for (auto const& p : expected)
-    {
-        EXPECT_TRUE(found.count(p));
-    }
-
-    removeDirIfExists(base);
-}
 
 TEST(SearchInFile, LinesContainingQuery_CaseSensitive)
 {
@@ -560,54 +528,3 @@ TEST(HandlesCarriageReturn, StripsCR)
     removeDirIfExists(base);
 }
 
-TEST(CollectFiles, SkipsPermissionDenied)
-{
-    auto base = fs::temp_directory_path() / "custom_grep_perm_denied";
-    removeDirIfExists(base);
-    fs::create_directories(base / "allowed");
-    fs::create_directories(base / "denied");
-
-    writeFile(base / "allowed" / "file1.txt", { "ok" });
-    writeFile(base / "denied" / "secret.txt", { "hidden" });
-
-    fs::permissions(base / "denied", fs::perms::none, fs::perm_options::replace);
-
-    testing::internal::CaptureStderr();
-    auto files = cgrep::FileCollector::collectFiles(base);
-    std::string output = testing::internal::GetCapturedStderr();
-
-    EXPECT_EQ(files.size(), 1u);
-    EXPECT_EQ(files[0], base / "allowed" / "file1.txt");
-    EXPECT_NE(output.find("Permission denied"), std::string::npos);
-
-    fs::permissions(base / "denied", fs::perms::owner_all,
-                    fs::perm_options::replace);
-    removeDirIfExists(base);
-}
-
-TEST(CollectFiles, ContinuesAfterPermissionDenied)
-{
-    auto base = fs::temp_directory_path() / "custom_grep_perm_continue";
-    removeDirIfExists(base);
-    fs::create_directories(base / "pre");
-    fs::create_directories(base / "denied");
-    fs::create_directories(base / "post");
-
-    writeFile(base / "pre" / "a.txt", { "ok" });
-    writeFile(base / "post" / "b.txt", { "ok" });
-    writeFile(base / "denied" / "secret.txt", { "hidden" });
-
-    fs::permissions(base / "denied", fs::perms::none, fs::perm_options::replace);
-
-    testing::internal::CaptureStderr();
-    auto files = cgrep::FileCollector::collectFiles(base);
-    std::string output = testing::internal::GetCapturedStderr();
-
-    std::set<fs::path> expected = { base / "pre" / "a.txt", base / "post" / "b.txt" };
-    std::set<fs::path> found(files.begin(), files.end());
-    EXPECT_EQ(found, expected);
-    EXPECT_NE(output.find("Permission denied"), std::string::npos);
-
-    fs::permissions(base / "denied", fs::perms::owner_all, fs::perm_options::replace);
-    removeDirIfExists(base);
-}

--- a/tests/TestFileCollector.cpp
+++ b/tests/TestFileCollector.cpp
@@ -1,0 +1,118 @@
+#include "FileCollector.h"
+
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+// Helper: write a file with the given lines (one per line)
+static void writeFile(const fs::path& path, const std::vector<std::string>& lines)
+{
+    std::ofstream ofs(path);
+    for (auto const& l : lines)
+    {
+        ofs << l << "\n";
+    }
+    ofs.close();
+    ASSERT_TRUE(fs::exists(path));
+}
+
+// Helper: recursively delete a directory if it exists
+static void removeDirIfExists(const fs::path& dir)
+{
+    if (fs::exists(dir))
+    {
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+        ASSERT_FALSE(ec);
+    }
+}
+
+TEST(CollectFiles, NestedDirectories)
+{
+    auto base = fs::temp_directory_path() / "custom_grep_test_dir";
+    removeDirIfExists(base);
+    fs::create_directories(base / "subdir1");
+    fs::create_directories(base / "subdir2" / "nested");
+
+    writeFile(base / "root1.txt", { "hello" });
+    writeFile(base / "root2.log", { "foo", "bar" });
+    writeFile(base / "subdir1" / "inside1.txt", { "inside" });
+    writeFile(base / "subdir1" / "inside2.txt", { "another" });
+    writeFile(base / "subdir2" / "nested" / "deep.txt", { "deep" });
+
+    auto files = cgrep::FileCollector::collectFiles(base);
+    EXPECT_EQ(files.size(), 5u);
+
+    std::set<fs::path> found(files.begin(), files.end());
+    std::vector<fs::path> expected =
+    {
+        base / "root1.txt",
+        base / "root2.log",
+        base / "subdir1" / "inside1.txt",
+        base / "subdir1" / "inside2.txt",
+        base / "subdir2" / "nested" / "deep.txt"
+    };
+    for (auto const& p : expected)
+    {
+        EXPECT_TRUE(found.count(p));
+    }
+
+    removeDirIfExists(base);
+}
+
+TEST(CollectFiles, SkipsPermissionDenied)
+{
+    auto base = fs::temp_directory_path() / "custom_grep_perm_denied";
+    removeDirIfExists(base);
+    fs::create_directories(base / "allowed");
+    fs::create_directories(base / "denied");
+
+    writeFile(base / "allowed" / "file1.txt", { "ok" });
+    writeFile(base / "denied" / "secret.txt", { "hidden" });
+
+    fs::permissions(base / "denied", fs::perms::none, fs::perm_options::replace);
+
+    testing::internal::CaptureStderr();
+    auto files = cgrep::FileCollector::collectFiles(base);
+    std::string output = testing::internal::GetCapturedStderr();
+
+    EXPECT_EQ(files.size(), 1u);
+    EXPECT_EQ(files[0], base / "allowed" / "file1.txt");
+    EXPECT_NE(output.find("Permission denied"), std::string::npos);
+
+    fs::permissions(base / "denied", fs::perms::owner_all,
+                    fs::perm_options::replace);
+    removeDirIfExists(base);
+}
+
+TEST(CollectFiles, ContinuesAfterPermissionDenied)
+{
+    auto base = fs::temp_directory_path() / "custom_grep_perm_continue";
+    removeDirIfExists(base);
+    fs::create_directories(base / "pre");
+    fs::create_directories(base / "denied");
+    fs::create_directories(base / "post");
+
+    writeFile(base / "pre" / "a.txt", { "ok" });
+    writeFile(base / "post" / "b.txt", { "ok" });
+    writeFile(base / "denied" / "secret.txt", { "hidden" });
+
+    fs::permissions(base / "denied", fs::perms::none, fs::perm_options::replace);
+
+    testing::internal::CaptureStderr();
+    auto files = cgrep::FileCollector::collectFiles(base);
+    std::string output = testing::internal::GetCapturedStderr();
+
+    std::set<fs::path> expected = { base / "pre" / "a.txt", base / "post" / "b.txt" };
+    std::set<fs::path> found(files.begin(), files.end());
+    EXPECT_EQ(found, expected);
+    EXPECT_NE(output.find("Permission denied"), std::string::npos);
+
+    fs::permissions(base / "denied", fs::perms::owner_all, fs::perm_options::replace);
+    removeDirIfExists(base);
+}
+


### PR DESCRIPTION
## Summary
- extract FileCollector tests into a new `TestFileCollector.cpp`
- update `CMakeLists.txt` to compile both test sources
- remove FileCollector tests from `TestCustomGrep.cpp`

## Testing
- `cmake -DBUILD_TESTS=ON ..` *(fails: cannot download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_685e95464aac8326b32b369cd7c5d95d